### PR TITLE
shellish -> shelly

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ instance Default Config where
 Most shell libraries require running their own monad that runs ontop
 of IO. For that, you can specify the `configRun` field to the
 configuration. There's an example for the
-[shellish](http://hackage.haskell.org/package/shellish) package
-[here](https://github.com/chrisdone/hell/blob/master/src/main/Shellish.hs).
+[shelly](http://hackage.haskell.org/package/shelly) package
+[here](https://github.com/chrisdone/hell/blob/master/src/main/Shelly.hs).
 
 ## Why “Hell”? Surely a Haskell shell would be heaven!
 

--- a/src/main/Shellish.hs
+++ b/src/main/Shellish.hs
@@ -1,6 +1,6 @@
 -- | A sample Hell configuration for the Shellish package.
 --
--- Remember to: cabal install shellish
+-- Remember to: cabal install shelly
 
 module Main where
 
@@ -8,8 +8,8 @@ import Hell
 
 -- | Main entry point.
 main :: IO ()
-main = startHell def { configRun = Just (\username pwd -> return "shellish")
-                     , configImports = "import Shellish" :
+main = startHell def { configRun = Just (\username pwd -> return "shelly")
+                     , configImports = "import Shelly" :
                                        filter (/= "import Hell.Prelude")
                                               (configImports def)
                      }


### PR DESCRIPTION
shellish hasn't been updated in years.

This is untested, I couldn't figure out how to get hell to work.

I don't understand how this worked with shellish.
Better integration would automaticatlly run the shellyNoDir function (which executes the monad) before each command.
