### PR TITLE
GHC 7.10 fixes

### DIFF
--- a/src/Hell/Shell.hs
+++ b/src/Hell/Shell.hs
@@ -31,7 +31,7 @@ import           Exception (ExceptionMonad)
 import           GHC hiding (History)
 import           GHC.Paths hiding (ghc)
 import           Name
-import           Outputable (Outputable(..),showSDoc)
+import           Outputable (Outputable(..),showSDocForUser,alwaysQualify)
 import           System.Console.Haskeline
 import           System.Console.Haskeline.History
 import           System.Directory
@@ -227,7 +227,7 @@ setFlags xs dflags = foldl xopt_set dflags xs
 -- | Something like Show but for things which annoyingly do not have
 -- Show but Outputable instead.
 showppr :: Outputable a => DynFlags -> a -> String
-showppr d = showSDoc d . ppr
+showppr d = showSDocForUser d alwaysQualify . ppr
 
 -- | Try the thing or return the exception.
 gtry :: (Functor m, ExceptionMonad m) => m a -> m (Either SomeException a)

--- a/src/Hell/Types.hs
+++ b/src/Hell/Types.hs
@@ -33,7 +33,7 @@ data HellState = HellState
 -- | Hell monad, containing user information and things like that.
 newtype Hell a =
   Hell {runHell :: ReaderT HellState Ghc a}
-  deriving (Monad,MonadIO,Functor,MonadReader HellState)
+  deriving (Functor,Applicative,Monad,MonadIO,MonadReader HellState)
 
 instance Default Config where
   def =


### PR DESCRIPTION
This fixes #12 by deriving an Applicative instance for Hell. Also, it appears that the GHC API is no longer qualifying types when just using `showSDoc`, confusing the expression routing when evaluating a command. This forces qualified printing, so that the old routing system works.