### PR TITLE
Disambiguate «cd» built-in.

### DIFF
--- a/src/Hell/Types.hs
+++ b/src/Hell/Types.hs
@@ -41,7 +41,7 @@ instance Default Config where
               ["import Prelude"
               ,"import Data.List"
               ,"import Data.Ord"
-              ,"import Data.Conduit.Shell"
+              ,"import Data.Conduit.Shell hiding (cd)"
               ,"import System.Directory"
               ,"import Data.Conduit"
               ,"import qualified Data.Conduit.List as CL"


### PR DESCRIPTION
It seems your `shell-conduit` package now also has a `cd` built-in that was in scope when evaluating expressions in Hell, so that the `cd` expression was ambiguous. This hides the other `cd`.