### PR TITLE
Update hell.cabal

### DIFF
--- a/hell.cabal
+++ b/hell.cabal
@@ -1,5 +1,5 @@
 name:                hell
-version:             2.1
+version:             2.2
 synopsis:            A Haskell shell based on shell-conduit
 description:         A Haskell shell based on shell-conduit
 license:             BSD3


### PR DESCRIPTION
Bump for hackage. 

Need the Applicative fix to be uploaded to hackage to install using latest ghc.