### PR TITLE
Add record support

### DIFF
--- a/examples/22-records.hell
+++ b/examples/22-records.hell
@@ -1,0 +1,9 @@
+data Person = Person { age :: Int, name :: Text }
+
+main = do
+  Text.putStrLn $ Record.get @"name" Main.person
+  Text.putStrLn $ Record.get @"name" $ Record.set @"name" "Mary" Main.person
+  Text.putStrLn $ Record.get @"name" $ Record.modify @"name" Text.reverse Main.person
+
+person =
+ Main.Person { name = "Chris", age = 23 }

--- a/hell.cabal
+++ b/hell.cabal
@@ -32,6 +32,7 @@ executable hell
     , mtl
     , optparse-applicative
     , syb
+    , tagged
     , template-haskell
     , text
     , typed-process

--- a/package.yaml
+++ b/package.yaml
@@ -19,6 +19,7 @@ dependencies:
 - typed-process
 - optparse-applicative
 - hspec
+- tagged
 - QuickCheck
 - template-haskell
 - unliftio


### PR DESCRIPTION
This adds support for records, like this:

https://github.com/chrisdone/hell/blob/944231cc2a4897026a8a005d6a899742a33a1fe1/examples/22-records.hell#L1-L9

The accessors, setters and modifiers aren't exactly Haskell-98 (perhaps more GHC2024), but otherwise declaration and construction are the same.