### PR TITLE
Support (in theory) GHC 9.6

### DIFF
--- a/src/Hell.hs
+++ b/src/Hell.hs
@@ -8,6 +8,7 @@
 -- made some of this more ergonomic.
 
 {-# options_ghc -Wno-unused-foralls #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ExistentialQuantification, TypeApplications, BlockArguments, NamedFieldPuns, DataKinds #-}
 {-# LANGUAGE GADTs, PolyKinds, TupleSections, StandaloneDeriving, Rank2Types, FlexibleContexts #-}
 {-# LANGUAGE ViewPatterns, LambdaCase, ScopedTypeVariables, PatternSynonyms, TemplateHaskell #-}
@@ -75,7 +76,10 @@ import Data.Vector (Vector)
 import Data.Aeson (Value)
 import Data.Text (Text)
 import Data.ByteString (ByteString)
-import GHC.Types
+#if __GLASGOW_HASKELL__ >= 906
+import Control.Monad
+#endif
+import GHC.Types (Type)
 import GHC.TypeLits
 import Type.Reflection (SomeTypeRep(..), TypeRep, typeRepKind, typeRep, pattern TypeRep)
 


### PR DESCRIPTION
@juhp I'm not sure why `Control.Monad` is needed -- I'd prefer to just add an explicit import.  Let me know if there's a specific name that isn't available anymore.

I'll need more time than a 5 min fix to upgrade my CI from GHC 9.4.8 to 9.6, so in the interim I don't mind throwing a CPP on there for the newer versions.