### PR TITLE
Include location of ambiguous meta variables in error messages

### DIFF
--- a/src/Hell.hs
+++ b/src/Hell.hs
@@ -1512,7 +1512,7 @@ data IRep v
 
 data ZonkError
  = ZonkKindError
- | AmbiguousMetavar
+ | AmbiguousMetavar IMetaVar
  deriving (Show)
 
 -- | A complete implementation of conversion from the inferer's type
@@ -1709,7 +1709,7 @@ occurs ivar = any (==ivar)
 -- <https://stackoverflow.com/questions/31889048/what-does-the-ghc-source-mean-by-zonk>
 zonk :: IRep IMetaVar -> Either ZonkError (IRep Void)
 zonk = \case
-  IVar {} -> Left AmbiguousMetavar
+  IVar var -> Left $ AmbiguousMetavar var
   ICon c -> pure $ ICon c
   IFun a b -> IFun <$> zonk a <*> zonk b
   IApp a b -> IApp <$> zonk a <*> zonk b
@@ -1868,7 +1868,10 @@ instance Pretty a => Pretty (IRep a) where
 instance Pretty ZonkError where
   pretty = \case
     ZonkKindError -> "Kind error."
-    AmbiguousMetavar -> "Ambiguous meta variable."
+    AmbiguousMetavar imetavar ->
+      "Ambiguous meta variable: " <> pretty imetavar <> "\n" <>
+       "arising from " <>
+         pretty imetavar.srcSpanInfo
 
 instance Pretty ElaborateError where
   pretty = \case


### PR DESCRIPTION
The following example now prints the error message below it:

```haskell
main = do
 let f = \x -> Eq.eq x x
 Text.putStrLn "OK"
```
```
*** Exception: Zonk error: Ambiguous meta variable: t2
arising from examples/zonk-error.hell:2:10
```

So you can actually find where a meta variable came from. Usually an unused variable.