### PR TITLE
Support referencing user-defined types from terms and other user-defined types

### DIFF
--- a/docs/examples/index.html
+++ b/docs/examples/index.html
@@ -437,4 +437,22 @@ class="sourceCode haskell"><code class="sourceCode haskell"><span id="cb1-1"><a 
 <span id="cb1-14"><a href="#cb1-14" aria-hidden="true" tabindex="-1"></a>    <span class="dt">Good</span> <span class="ot">-&gt;</span> <span class="st">&quot;Good!&quot;</span></span>
 <span id="cb1-15"><a href="#cb1-15" aria-hidden="true" tabindex="-1"></a>    <span class="dt">Bad</span> <span class="ot">-&gt;</span> <span class="st">&quot;Bad!&quot;</span></span>
 <span id="cb1-16"><a href="#cb1-16" aria-hidden="true" tabindex="-1"></a>    <span class="dt">Ugly</span> <span class="ot">-&gt;</span> <span class="st">&quot;Ugly!&quot;</span></span></code></pre></div>
+<h2>26-reference-other-types.hell</h2><div class="sourceCode" id="cb1"><pre
+class="sourceCode haskell"><code class="sourceCode haskell"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- User-defined types can reference other types now.</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="kw">data</span> <span class="dt">Person</span> <span class="ot">=</span> <span class="dt">Person</span> {</span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="ot">  name ::</span> <span class="dt">Text</span>,</span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a><span class="ot">  address ::</span> <span class="dt">Main.Address</span></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a><span class="kw">data</span> <span class="dt">Address</span> <span class="ot">=</span> <span class="dt">Address</span> {</span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a><span class="ot">  line1 ::</span> <span class="dt">Text</span>,<span class="ot"> line2 ::</span> <span class="dt">Text</span></span>
+<span id="cb1-8"><a href="#cb1-8" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb1-9"><a href="#cb1-9" aria-hidden="true" tabindex="-1"></a>main <span class="ot">=</span> <span class="kw">do</span></span>
+<span id="cb1-10"><a href="#cb1-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">let</span><span class="ot"> p ::</span> <span class="dt">Main.Person</span> <span class="ot">=</span> <span class="dt">Main.Person</span> { name <span class="ot">=</span> <span class="st">&quot;Chris&quot;</span>, address <span class="ot">=</span> <span class="dt">Main.Address</span> { line1 <span class="ot">=</span> <span class="st">&quot;1 North Pole&quot;</span>, line2 <span class="ot">=</span> <span class="st">&quot;Earth&quot;</span> } }</span>
+<span id="cb1-11"><a href="#cb1-11" aria-hidden="true" tabindex="-1"></a>  Text.putStrLn <span class="op">$</span> Record.get <span class="op">@</span><span class="st">&quot;name&quot;</span> p</span>
+<span id="cb1-12"><a href="#cb1-12" aria-hidden="true" tabindex="-1"></a>  Text.putStrLn <span class="op">$</span></span>
+<span id="cb1-13"><a href="#cb1-13" aria-hidden="true" tabindex="-1"></a>    Record.get <span class="op">@</span><span class="st">&quot;line1&quot;</span> <span class="op">@</span><span class="dt">Text</span> <span class="op">$</span></span>
+<span id="cb1-14"><a href="#cb1-14" aria-hidden="true" tabindex="-1"></a>      Record.get <span class="op">@</span><span class="st">&quot;address&quot;</span> <span class="op">@</span><span class="dt">Main.Address</span> p</span>
+<span id="cb1-15"><a href="#cb1-15" aria-hidden="true" tabindex="-1"></a>      <span class="co">--                    ^ Unfortunately this is needed or else the</span></span>
+<span id="cb1-16"><a href="#cb1-16" aria-hidden="true" tabindex="-1"></a>      <span class="co">--                    nested access causes an ambiguous type</span></span>
+<span id="cb1-17"><a href="#cb1-17" aria-hidden="true" tabindex="-1"></a>      <span class="co">--                    variable. But it&#39;s not too bad.</span></span></code></pre></div>
 </html>

--- a/examples/26-reference-other-types.hell
+++ b/examples/26-reference-other-types.hell
@@ -1,0 +1,17 @@
+-- User-defined types can reference other types now.
+data Person = Person {
+  name :: Text,
+  address :: Main.Address
+  }
+data Address = Address {
+  line1 :: Text, line2 :: Text
+}
+main = do
+  let p :: Main.Person = Main.Person { name = "Chris", address = Main.Address { line1 = "1 North Pole", line2 = "Earth" } }
+  Text.putStrLn $ Record.get @"name" p
+  Text.putStrLn $
+    Record.get @"line1" @Text $
+      Record.get @"address" @Main.Address p
+      --                    ^ Unfortunately this is needed or else the
+      --                    nested access causes an ambiguous type
+      --                    variable. But it's not too bad.


### PR DESCRIPTION
Adds support for referencing other types, as in this example:

```haskell
-- User-defined types can reference other types now.
data Person = Person {
  name :: Text,
  address :: Main.Address
  }
data Address = Address {
  line1 :: Text, line2 :: Text
}
main = do
  let p :: Main.Person = Main.Person { name = "Chris", address = Main.Address { line1 = "1 North Pole", line2 = "Earth" } }
  Text.putStrLn $ Record.get @"name" p
  Text.putStrLn $
    Record.get @"line1" @Text $
      Record.get @"address" @Main.Address p
      --                    ^ Unfortunately this is needed or else the
      --                    nested access causes an ambiguous type
      --                    variable. But it's not too bad.

```