### PR TITLE
Hide primitive names

### DIFF
--- a/src/Hell.hs
+++ b/src/Hell.hs
@@ -296,11 +296,10 @@ desugarVariantType = appRecord . foldr appCons nilL
     appCons (name, typ) rest =
       HSE.TyApp l (HSE.TyApp l (HSE.TyApp l consL (tySym name)) typ) rest
     appRecord x =
-      HSE.TyParen l (HSE.TyApp l recordT x)
+      HSE.TyParen l (HSE.TyApp l (hellVariantTyCon l) x)
     tySym s = HSE.TyPromoted l (HSE.PromotedString l s s)
     nilL = HSE.TyCon l (HSE.UnQual l (HSE.Ident l "NilL"))
     consL = HSE.TyCon l (HSE.UnQual l (HSE.Ident l "ConsL"))
-    recordT = HSE.TyCon l (HSE.UnQual l (HSE.Ident l "Variant"))
     l = HSE.noSrcSpan
 
 parseConDecl :: (MonadFail f) => HSE.QualConDecl l -> f (String, HSE.Type l)
@@ -398,11 +397,10 @@ desugarRecordType = appRecord . foldr appCons nilL
     appCons (name, typ) rest =
       HSE.TyApp l (HSE.TyApp l (HSE.TyApp l consL (tySym name)) typ) rest
     appRecord x =
-      HSE.TyApp l recordT x
+      HSE.TyApp l (hellRecordTyCon l) x
     tySym s = HSE.TyPromoted l (HSE.PromotedString l s s)
     nilL = HSE.TyCon l (HSE.UnQual l (HSE.Ident l "NilL"))
     consL = HSE.TyCon l (HSE.UnQual l (HSE.Ident l "ConsL"))
-    recordT = HSE.TyCon l (HSE.UnQual l (HSE.Ident l "Record"))
     l = HSE.noSrcSpan
 
 --------------------------------------------------------------------------------
@@ -1142,12 +1140,12 @@ supportedTypeConstructors =
       ("()", SomeTypeRep $ typeRep @()),
 
       -- Internal, not yet hidden types
-      ("Record", SomeTypeRep $ typeRep @Record),
-      ("Variant", SomeTypeRep $ typeRep @Variant),
       ("NilL", SomeTypeRep $ typeRep @('NilL)),
       ("ConsL", SomeTypeRep $ typeRep @('ConsL)),
 
       -- Internal, hidden types
+      ("hell:Hell.Variant", SomeTypeRep $ typeRep @Variant),
+      ("hell:Hell.Record", SomeTypeRep $ typeRep @Record),
       ("hell:Hell.Tagged", SomeTypeRep $ typeRep @Tagged),
       ("hell:Hell.Nullary", SomeTypeRep $ typeRep @Nullary)
     ]
@@ -1639,6 +1637,12 @@ hellCon l string = HSE.Con l $ hellQName l string
 
 hellTaggedTyCon :: l -> HSE.Type l
 hellTaggedTyCon l = hellTyCon l "Tagged"
+
+hellRecordTyCon :: l -> HSE.Type l
+hellRecordTyCon l = hellTyCon l "Record"
+
+hellVariantTyCon :: l -> HSE.Type l
+hellVariantTyCon l = hellTyCon l "Variant"
 
 hellTaggedCon :: l -> HSE.Exp l
 hellTaggedCon l = hellCon l "Tagged"

--- a/src/Hell.hs
+++ b/src/Hell.hs
@@ -265,8 +265,7 @@ parseSumDecl _ _ =
 desugarVariantCon :: Bool -> [String] -> String -> HSE.Exp HSE.SrcSpanInfo
 desugarVariantCon nullary cons thisCon = rights $ left
   where
-    right _ =
-      HSE.Var l (HSE.Qual l (HSE.ModuleName l "Variant") (HSE.Ident l "right"))
+    right _ = HSE.Var l (hellQName l "RightV")
     rights e = foldr (HSE.App l) e $ map right $ takeWhile (/= thisCon) cons
     left =
       if nullary
@@ -284,7 +283,7 @@ desugarVariantCon nullary cons thisCon = rights $ left
         left0 =
           ( HSE.App
               l
-              (HSE.Var l (HSE.Qual l (HSE.ModuleName l "Variant") (HSE.Ident l "left")))
+              (HSE.Var l (hellQName l "LeftV"))
               (HSE.TypeApp l (tySym thisCon))
           )
     tySym s = HSE.TyPromoted l (HSE.PromotedString l s s)
@@ -373,7 +372,7 @@ makeConstructRecord qname fields =
                     l
                     ( HSE.App
                         l
-                        (HSE.Var l (HSE.Qual l (HSE.ModuleName l "Record") (HSE.Ident l "cons")))
+                        (HSE.Var l (hellQName l "ConsR"))
                         (HSE.TypeApp l (tySym name))
                     )
                     expr
@@ -784,20 +783,13 @@ desugarCase l scrutinee xs = do
     nil =
       ( HSE.Var
           l
-          ( HSE.Qual
-              l
-              (HSE.ModuleName l "Variant")
-              (HSE.Ident l "nil")
+          ( hellQName l "NilA"
           )
       )
     run =
       ( HSE.Var
           l
-          ( HSE.Qual
-              l
-              (HSE.ModuleName l "Variant")
-              (HSE.Ident l "run")
-          )
+          ( hellQName l "runAccessor")
       )
     desugarAlt
       ( HSE.Alt
@@ -819,11 +811,7 @@ desugarCase l scrutinee xs = do
                   l'
                   ( HSE.Var
                       l'
-                      ( HSE.Qual
-                          l'
-                          (HSE.ModuleName l' "Variant")
-                          (HSE.Ident l' "cons")
-                      )
+                      ( hellQName l' "ConsA")
                   )
                   (HSE.TypeApp l' (tySym name))
               )
@@ -849,11 +837,7 @@ desugarCase l scrutinee xs = do
                   l'
                   ( HSE.Var
                       l'
-                      ( HSE.Qual
-                          l'
-                          (HSE.ModuleName l' "Variant")
-                          (HSE.Ident l' "cons")
-                      )
+                      ( hellQName l' "ConsA")
                   )
                   (HSE.TypeApp l' (tySym name))
               )
@@ -1421,16 +1405,16 @@ polyLits =
              [|
                do
                  -- Records
-                 "Record.cons" ConsR :: forall (k :: Symbol) a (xs :: List). a -> Record xs -> Record (ConsL k a xs)
+                 "hell:Hell.ConsR" ConsR :: forall (k :: Symbol) a (xs :: List). a -> Record xs -> Record (ConsL k a xs)
                  "Record.get" _ :: forall (k :: Symbol) a (t :: Symbol) (xs :: List). Tagged t (Record xs) -> a
                  "Record.set" _ :: forall (k :: Symbol) a (t :: Symbol) (xs :: List). a -> Tagged t (Record xs) -> Tagged t (Record xs)
                  "Record.modify" _ :: forall (k :: Symbol) a (t :: Symbol) (xs :: List). (a -> a) -> Tagged t (Record xs) -> Tagged t (Record xs)
                  -- Variants
-                 "Variant.left" LeftV :: forall (k :: Symbol) a (xs :: List). a -> Variant (ConsL k a xs)
-                 "Variant.right" RightV :: forall (k :: Symbol) a (xs :: List) (k'' :: Symbol) a''. Variant (ConsL k'' a'' xs) -> Variant (ConsL k a (ConsL k'' a'' xs))
-                 "Variant.nil" NilA :: forall r. Accessor 'NilL r
-                 "Variant.cons" ConsA :: forall (k :: Symbol) a r (xs :: List). (a -> r) -> Accessor xs r -> Accessor (ConsL k a xs) r
-                 "Variant.run" runAccessor :: forall (t :: Symbol) r (xs :: List). Tagged t (Variant xs) -> Accessor xs r -> r
+                 "hell:Hell.LeftV" LeftV :: forall (k :: Symbol) a (xs :: List). a -> Variant (ConsL k a xs)
+                 "hell:Hell.RightV" RightV :: forall (k :: Symbol) a (xs :: List) (k'' :: Symbol) a''. Variant (ConsL k'' a'' xs) -> Variant (ConsL k a (ConsL k'' a'' xs))
+                 "hell:Hell.NilA" NilA :: forall r. Accessor 'NilL r
+                 "hell:Hell.ConsA" ConsA :: forall (k :: Symbol) a r (xs :: List). (a -> r) -> Accessor xs r -> Accessor (ConsL k a xs) r
+                 "hell:Hell.runAccessor" runAccessor :: forall (t :: Symbol) r (xs :: List). Tagged t (Variant xs) -> Accessor xs r -> r
                  -- Tagged
                  "hell:Hell.Tagged" Tagged :: forall (t :: Symbol) a. a -> Tagged t a
                  -- Operators

--- a/src/Hell.hs
+++ b/src/Hell.hs
@@ -275,7 +275,7 @@ desugarVariantCon nullary cons thisCon = rights $ left
           HSE.App
             l
             left0
-            (HSE.Con l (HSE.Qual l (HSE.ModuleName l "hell:Hell") (HSE.Ident l "Nullary")))
+            (HSE.Con l (hellQName l "Nullary"))
         else
           HSE.App
             l
@@ -308,16 +308,7 @@ parseConDecl :: (MonadFail f) => HSE.QualConDecl l -> f (String, HSE.Type l)
 parseConDecl (HSE.QualConDecl _ Nothing Nothing (HSE.ConDecl _ (HSE.Ident _ consName) [slot])) =
   pure (consName, slot)
 parseConDecl (HSE.QualConDecl l Nothing Nothing (HSE.ConDecl _ (HSE.Ident _ consName) [])) =
-  pure
-    ( consName,
-      HSE.TyCon
-        l
-        ( HSE.Qual
-            l
-            (HSE.ModuleName l "hell:Hell")
-            (HSE.Ident l "Nullary")
-        )
-    )
+  pure ( consName, hellTyCon l "Nullary")
 parseConDecl _ = fail "Unsupported constructor declaration format."
 
 parseDataDecl :: (l ~ HSE.SrcSpanInfo) =>
@@ -1626,6 +1617,18 @@ unsafeGetForall :: String -> HSE.SrcSpanInfo -> UTerm ()
 unsafeGetForall key l = Maybe.fromMaybe (error $ "Bad compile-time lookup for " ++ key) $ do
   (forall', vars, irep, _) <- Map.lookup key polyLits
   pure (UForall l () [] forall' vars irep [])
+
+--------------------------------------------------------------------------------
+-- Hidden terms and types, implementation-detail, used by Hell
+
+hellModule :: l -> HSE.ModuleName l
+hellModule l = HSE.ModuleName l "hell:Hell"
+
+hellQName :: l -> String -> HSE.QName l
+hellQName l string = HSE.Qual l (hellModule l) (HSE.Ident l string)
+
+hellTyCon :: l -> String -> HSE.Type l
+hellTyCon l string = HSE.TyCon l $ hellQName l string
 
 --------------------------------------------------------------------------------
 -- Accessor for ExitCode

--- a/src/Hell.hs
+++ b/src/Hell.hs
@@ -298,8 +298,8 @@ desugarVariantType = appRecord . foldr appCons nilL
     appRecord x =
       HSE.TyParen l (HSE.TyApp l (hellVariantTyCon l) x)
     tySym s = HSE.TyPromoted l (HSE.PromotedString l s s)
-    nilL = HSE.TyCon l (HSE.UnQual l (HSE.Ident l "NilL"))
-    consL = HSE.TyCon l (HSE.UnQual l (HSE.Ident l "ConsL"))
+    nilL = hellNilTyCon l
+    consL = hellConsTyCon l
     l = HSE.noSrcSpan
 
 parseConDecl :: (MonadFail f) => HSE.QualConDecl l -> f (String, HSE.Type l)
@@ -399,8 +399,8 @@ desugarRecordType = appRecord . foldr appCons nilL
     appRecord x =
       HSE.TyApp l (hellRecordTyCon l) x
     tySym s = HSE.TyPromoted l (HSE.PromotedString l s s)
-    nilL = HSE.TyCon l (HSE.UnQual l (HSE.Ident l "NilL"))
-    consL = HSE.TyCon l (HSE.UnQual l (HSE.Ident l "ConsL"))
+    nilL = hellNilTyCon l
+    consL = hellConsTyCon l
     l = HSE.noSrcSpan
 
 --------------------------------------------------------------------------------
@@ -1139,11 +1139,9 @@ supportedTypeConstructors =
       ("ProcessConfig", SomeTypeRep $ typeRep @ProcessConfig),
       ("()", SomeTypeRep $ typeRep @()),
 
-      -- Internal, not yet hidden types
-      ("NilL", SomeTypeRep $ typeRep @('NilL)),
-      ("ConsL", SomeTypeRep $ typeRep @('ConsL)),
-
       -- Internal, hidden types
+      ("hell:Hell.NilL", SomeTypeRep $ typeRep @('NilL)),
+      ("hell:Hell.ConsL", SomeTypeRep $ typeRep @('ConsL)),
       ("hell:Hell.Variant", SomeTypeRep $ typeRep @Variant),
       ("hell:Hell.Record", SomeTypeRep $ typeRep @Record),
       ("hell:Hell.Tagged", SomeTypeRep $ typeRep @Tagged),
@@ -1643,6 +1641,12 @@ hellRecordTyCon l = hellTyCon l "Record"
 
 hellVariantTyCon :: l -> HSE.Type l
 hellVariantTyCon l = hellTyCon l "Variant"
+
+hellNilTyCon :: l -> HSE.Type l
+hellNilTyCon l = hellTyCon l "NilL"
+
+hellConsTyCon :: l -> HSE.Type l
+hellConsTyCon l = hellTyCon l "ConsL"
 
 hellTaggedCon :: l -> HSE.Exp l
 hellTaggedCon l = hellCon l "Tagged"

--- a/src/Hell.hs
+++ b/src/Hell.hs
@@ -380,7 +380,7 @@ makeConstructRecord qname fields =
                 )
                 rest
       )
-      (HSE.Var l (HSE.Qual l (HSE.ModuleName l "Record") (HSE.Ident l "nil")))
+      (HSE.Var l (hellQName l "NilR"))
     $ List.sortBy (Ord.comparing fst)
     $ map
       ( \case
@@ -1275,7 +1275,7 @@ supportedLits =
       ("Json.Array", lit' (Json.toJSON :: Vector Value -> Value)),
       ("Json.Object", lit' (Json.toJSON :: Map Text Value -> Value)),
       -- Records
-      ("Record.nil", lit' NilR),
+      ("hell:Hell.NilR", lit' NilR),
       -- Nullary
       ("hell:Hell.Nullary", lit' Nullary)
     ]
@@ -2230,11 +2230,16 @@ _generateApiDocs = do
         h1_ "Hell's API"
         p_ $ a_ [href_ "../"] $ "Back to homepage"
         h2_ "Types"
+        let excludeHidden = filter (not . List.isPrefixOf "hell:Hell." . fst)
         ul_ do
-          for_ (Map.toList supportedTypeConstructors) typeConsToHtml
+          for_ (excludeHidden $ Map.toList supportedTypeConstructors) typeConsToHtml
         h2_ "Terms"
-        let groups = Map.toList $ fmap (Left . snd) supportedLits
-        let groups' = Map.toList $ fmap (\(_, _, _, ty) -> Right ty) polyLits
+        let groups =
+              excludeHidden $
+              Map.toList $ fmap (Left . snd) $
+               supportedLits
+        let groups' = excludeHidden  $
+              Map.toList $ fmap (\(_, _, _, ty) -> Right ty) polyLits
         for_ (List.groupBy (Function.on (==) (takeWhile (/= '.') . fst)) $ List.sortOn fst $ groups <> groups') \group -> do
           h3_ $ for_ (take 1 group) \(x, _) -> toHtml $ takeWhile (/= '.') x
           ul_ do


### PR DESCRIPTION
By prefixing them with `hell:Hell`. They are then hidden from the API documentation, and cannot be syntactically written in a Hell program.