### PR TITLE
add `Process.useHandleOpen` primitive

### DIFF
--- a/examples/30-process-handlers.hell
+++ b/examples/30-process-handlers.hell
@@ -1,8 +1,23 @@
 main = do
+  -- 1. close the handle after the process
   Temp.withSystemTempFile "example" \filePath handle -> do
     Text.putStrLn $ Text.concat ["Created temp file ", filePath]
     let proc = Process.setStdout (Process.useHandleClose handle) $ 
          Process.proc "ls" ["-al"]
     Process.runProcess_ proc
+    contents <- Text.readFile filePath
+    Text.putStrLn contents
+
+  -- 2. keep the handle open after the process
+  Temp.withSystemTempFile "example-open" \filePath handle -> do
+    Text.putStrLn $ Text.concat ["Created temp file ", filePath]
+    let proc0 = Process.setStdout (Process.useHandleOpen handle) $ 
+         Process.proc "echo" ["hello"]
+    -- second time around we we make sure to close the handle 
+    -- so we can then read the file later
+    let proc1 = Process.setStdout (Process.useHandleClose handle) $ 
+         Process.proc "echo" ["world"]
+    Process.runProcess_ proc0
+    Process.runProcess_ proc1
     contents <- Text.readFile filePath
     Text.putStrLn contents

--- a/src/Hell.hs
+++ b/src/Hell.hs
@@ -1603,7 +1603,8 @@ polyLits =
                  "Process.runProcess" runProcess :: forall a b c. ProcessConfig a b c -> IO ExitCode
                  "Process.runProcess_" runProcess_ :: forall a b c. ProcessConfig a b c -> IO ()
                  "Process.setStdout" setStdout :: forall stdin stdout stdout' stderr. StreamSpec 'STOutput stdout' -> ProcessConfig stdin stdout stderr -> ProcessConfig stdin stdout' stderr
-                 "Process.useHandleClose" useHandleClose :: forall (a :: StreamType). IO.Handle -> StreamSpec a ()
+                 "Process.useHandleClose" useHandleClose :: forall (a :: StreamType). IO.Handle -> StreamSpec a () 
+                 "Process.useHandleOpen" useHandleOpen :: forall (a :: StreamType). IO.Handle -> StreamSpec a () 
                |]
      )
 


### PR DESCRIPTION
Sometimes, we want to keep a handle open after running a process. This function exists at [`useHandleOpen` in the typed-process lib](https://hackage.haskell.org/package/typed-process-0.2.12.0/docs/System-Process-Typed.html#v:useHandleOpen).

I add to the process handlers example to showcase the two cases.

