### PR TITLE
Add `IO.hClose` primitve

### DIFF
--- a/examples/30-process-handlers.hell
+++ b/examples/30-process-handlers.hell
@@ -21,3 +21,14 @@ main = do
     Process.runProcess_ proc1
     contents <- Text.readFile filePath
     Text.putStrLn contents
+
+  -- 3. manually close the handle
+  Temp.withSystemTempFile "example-manual-close" \filePath handle -> do
+    Text.putStrLn $ Text.concat ["Created temp file ", filePath]
+    let proc = Process.setStdout (Process.useHandleOpen handle) $ 
+         Process.proc "echo" ["hello"]
+    Process.runProcess_ proc
+    -- manually close the handle so we can open the file to be read
+    IO.hClose handle
+    contents <- Text.readFile filePath
+    Text.putStrLn contents

--- a/src/Hell.hs
+++ b/src/Hell.hs
@@ -1232,6 +1232,7 @@ supportedLits =
       ("IO.NoBuffering", lit' IO.NoBuffering),
       ("IO.LineBuffering", lit' IO.LineBuffering),
       ("IO.BlockBuffering", lit' IO.BlockBuffering),
+      ("IO.hClose", lit' IO.hClose),
       -- Concurrent stuff
       ("Concurrent.threadDelay", lit' Concurrent.threadDelay),
       -- Bool


### PR DESCRIPTION
This corresponds to [`System.IO.hClose`](https://hackage.haskell.org/package/base-4.18.1.0/docs/System-IO.html#v:hClose) in haskell.

I've added an example too.