### PR TITLE
Add `Process.setWorkingDir` and `IO.openFile` (and constructors)

### DIFF
--- a/examples/09-processes.hell
+++ b/examples/09-processes.hell
@@ -14,4 +14,7 @@ main = do
 
   let config = Process.proc "false" []
   code <- Process.runProcess config
+
+  Process.runProcess $ Process.setWorkingDir "/etc/" $ Process.proc "pwd" []
+
   Text.putStrLn "Done."

--- a/examples/31-open-file-handle.hell
+++ b/examples/31-open-file-handle.hell
@@ -1,0 +1,10 @@
+main = do
+  let filepath = "out.txt"
+  handle <- IO.openFile filepath IO.WriteMode
+  let proc = Process.setStdout (Process.useHandleClose handle) $ 
+         Process.proc "ls" ["-al"]
+  Process.runProcess_ proc
+  IO.hClose handle
+
+  contents <- Text.readFile filepath
+  Text.putStrLn contents

--- a/src/Hell.hs
+++ b/src/Hell.hs
@@ -1229,6 +1229,11 @@ supportedLits =
       ("IO.LineBuffering", lit' IO.LineBuffering),
       ("IO.BlockBuffering", lit' IO.BlockBuffering),
       ("IO.hClose", lit' IO.hClose),
+      ("IO.openFile", lit' (\f m -> IO.openFile (Text.unpack f) m)),
+      ("IO.ReadMode", lit' IO.ReadMode),
+      ("IO.WriteMode", lit' IO.WriteMode),
+      ("IO.AppendMode", lit' IO.AppendMode),
+      ("IO.ReadWriteMode", lit' IO.ReadWriteMode),
       -- Concurrent stuff
       ("Concurrent.threadDelay", lit' Concurrent.threadDelay),
       -- Bool

--- a/src/Hell.hs
+++ b/src/Hell.hs
@@ -1600,8 +1600,9 @@ polyLits =
                  "Process.runProcess" runProcess :: forall a b c. ProcessConfig a b c -> IO ExitCode
                  "Process.runProcess_" runProcess_ :: forall a b c. ProcessConfig a b c -> IO ()
                  "Process.setStdout" setStdout :: forall stdin stdout stdout' stderr. StreamSpec 'STOutput stdout' -> ProcessConfig stdin stdout stderr -> ProcessConfig stdin stdout' stderr
-                 "Process.useHandleClose" useHandleClose :: forall (a :: StreamType). IO.Handle -> StreamSpec a ()
-                 "Process.useHandleOpen" useHandleOpen :: forall (a :: StreamType). IO.Handle -> StreamSpec a ()
+                 "Process.useHandleClose" useHandleClose :: forall (a :: StreamType). IO.Handle -> StreamSpec a () 
+                 "Process.useHandleOpen" useHandleOpen :: forall (a :: StreamType). IO.Handle -> StreamSpec a () 
+                 "Process.setWorkingDir" process_setWorkingDir :: forall a b c. Text -> ProcessConfig a b c -> ProcessConfig a b c
                |]
      )
 
@@ -1769,6 +1770,12 @@ temp_withSystemTempFile template action = Temp.withSystemTempFile (Text.unpack t
 
 temp_withSystemTempDirectory :: forall a. Text -> (Text -> IO a) -> IO a
 temp_withSystemTempDirectory template action = Temp.withSystemTempDirectory (Text.unpack template) $ \fp -> action (Text.pack fp)
+
+--------------------------------------------------------------------------------
+-- Process operations
+
+process_setWorkingDir :: forall a b c. Text -> ProcessConfig a b c -> ProcessConfig a b c
+process_setWorkingDir filepath = Process.setWorkingDir (Text.unpack filepath)
 
 --------------------------------------------------------------------------------
 -- Inference type representation


### PR DESCRIPTION
This adds a couple of functions to the standard libary.

[`Process.setWorkingDir`](https://hackage.haskell.org/package/typed-process-0.2.12.0/docs/System-Process-Typed.html#v:setWorkingDir), for when you want a process to run in a certain dir. (This avoids having to `cd` in and out again).

[`IO.openFIle`](https://hackage.haskell.org/package/base-4.21.0.0/docs/System-IO.html#v:openFile). This is useful if you want fine grained control when writing to a file, rather than doing it in one go as `Text.writeFIle` etc. Typically this is useful when running processes concurrently, and you want the stdout to be written to a file in real time.