### PR TITLE
Add `IO.Handle` as type

### DIFF
--- a/hell.cabal
+++ b/hell.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 

--- a/package.yaml
+++ b/package.yaml
@@ -5,7 +5,7 @@ author: "Chris Done"
 copyright: "2023 Chris Done"
 synopsis: "Haskell-based shell scripting language"
 dependencies:
-- base >= 4.17.2.1 && < 4.18
+- base >= 4.17.2.1 && < 4.19
 - haskell-src-exts
 - ghc-prim
 - containers

--- a/src/Hell.hs
+++ b/src/Hell.hs
@@ -1165,6 +1165,7 @@ supportedTypeConstructors =
       ("Tree", SomeTypeRep $ typeRep @Tree),
       ("Value", SomeTypeRep $ typeRep @Value),
       ("()", SomeTypeRep $ typeRep @()),
+      ("Handle", SomeTypeRep $ typeRep @IO.Handle),
 
       -- Internal, hidden types
       ("hell:Hell.NilL", SomeTypeRep $ typeRep @('NilL)),


### PR DESCRIPTION
I wanted to make a record with a field which has type `Handle` but it wasn't exposed. This just exposes it (and regens the docs).