### PR TITLE
Add `These` constructors and `These.these` function

### DIFF
--- a/examples/36-these.hell
+++ b/examples/36-these.hell
@@ -1,0 +1,9 @@
+main = do
+  let things = [These.This 1, These.That "hello", These.These 2 "bonjour"]
+
+  Monad.forM_  things $ \thing -> Text.putStrLn $
+    These.these
+      (\i -> Show.show i)
+      (\s -> s)
+      (\i s -> Text.concat [Show.show i, " ", s])
+      thing

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730170245,
-        "narHash": "sha256-PRq4vJjDa+m1mNwkV9H7zVzMhuMqsHJrTGx0iJZ0e0w=",
+        "lastModified": 1741037377,
+        "narHash": "sha256-SvtvVKHaUX4Owb+PasySwZsoc5VUeTf1px34BByiOxw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "30c9efeef01e2ad4880bff6a01a61dd99536b3c9",
+        "rev": "02032da4af073d0f6110540c8677f16d4be0117f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,12 +7,13 @@
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs    = nixpkgs.legacyPackages.${system};
+        pkgs = nixpkgs.legacyPackages.${system};
         overlay = final: prev: {
           hell = prev.callCabal2nix "hell" ./. { };
         };
-        haskellPackages = pkgs.haskellPackages.extend overlay;
-      in {
+        haskellPackages = pkgs.haskell.packages.ghc910.extend overlay;
+      in
+      {
         # nix build
         packages.default = haskellPackages.hell;
 

--- a/hell.cabal
+++ b/hell.cabal
@@ -39,6 +39,7 @@ executable hell
     , text
     , th-lift
     , th-orphans
+    , these
     , typed-process
     , unliftio
     , vector

--- a/package.yaml
+++ b/package.yaml
@@ -28,6 +28,7 @@ dependencies:
 - th-orphans
 - aeson
 - temporary
+- these
 
 ghc-options:
   - -Wall

--- a/src/Hell.hs
+++ b/src/Hell.hs
@@ -80,6 +80,8 @@ import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Tree (Tree)
+import Data.These (These)
+import qualified Data.These as These
 import qualified Data.Tree as Tree
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.IO as Text
@@ -1203,6 +1205,7 @@ supportedTypeConstructors =
       ("IO", SomeTypeRep $ typeRep @IO),
       ("Vector", SomeTypeRep $ typeRep @Vector),
       ("Set", SomeTypeRep $ typeRep @Set),
+      ("These", SomeTypeRep $ typeRep @These),
       ("Tree", SomeTypeRep $ typeRep @Tree),
       ("Value", SomeTypeRep $ typeRep @Value),
       ("()", SomeTypeRep $ typeRep @()),
@@ -1588,6 +1591,11 @@ polyLits =
                  "Set.toList" Set.toList :: forall a. Set a -> [a]
                  "Set.size" Set.size :: forall a. Set a -> Int
                  "Set.singleton" Set.singleton :: forall a. (Ord a) => a -> Set a
+                 -- These
+                 "These.This" These.This :: forall a b. a -> These a b
+                 "These.That" These.That :: forall a b. b -> These a b
+                 "These.These" These.These :: forall a b. a -> b -> These a b
+                 "These.these" These.these :: forall a b c. (a -> c) -> (b -> c) -> (a -> b -> c) -> These a b -> c
                  -- Trees
                  "Tree.Node" Tree.Node :: forall a. a -> [Tree a] -> Tree a
                  "Tree.unfoldTree" Tree.unfoldTree :: forall a b. (b -> (a, [b])) -> b -> Tree a

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: abcc4a65c15c7c2313f1a87f01bfd4d910516e1930b99653eef1d2d006515916
-    size: 640074
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/24.yaml
-  original: lts-21.24
+    sha256: 867086a789eaf6da9f48a56bb5e8bfd6df27b120023c144cc7bbec5c95717915
+    size: 669588
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2024/10/21.yaml
+  original: nightly-2024-10-21


### PR DESCRIPTION
This adds basic support for the `These` type in [Data.These](https://hackage.haskell.org/package/these-1.2/docs/Data-These.html).

Along the way I bumped nixpkgs and pinned the ghc version (to 9.10 in this case).

See the example for how it looks:
https://github.com/chrisdone/hell/blob/d22c20156ad1b7e217142fb1ebdaf97d693950d8/examples/36-these.hell#L1-L9