### PR TITLE
add Semigroup instance for InfoMod

### DIFF
--- a/src/Hell.hs
+++ b/src/Hell.hs
@@ -930,6 +930,7 @@ instances =
         entail1 @Semigroup @Maybe,
         instance2 @Semigroup @Either,
         instance2 @Semigroup @Options.Mod,
+        instance1 @Semigroup @Options.InfoMod,
         instance0 @Semigroup @Text,
         instance0 @Semigroup @Builder,
         instance1 @Semigroup @Vector,


### PR DESCRIPTION
There is no Semigroup instance for InfoMod, preventing writing something like this, like I'd write in plain Haskell (taken from `examples/41-commands.hell`, modified):
```haskell
main = do
  let opts = Options.info (Main.cmdParser <**> Options.helper) 
    (Options.fullDesc <> Options.header "Program is distributed AS IS, without ANY warranty claims")
  cmd <- Options.execParser opts
  case cmd of
    Add f    -> Text.putStrLn $ "Adding " <> f
    Remove f -> Text.putStrLn $ "Removing " <> f
    List     -> Text.putStrLn "Listing files"
```

PS. I stumbled upon this project and it is quite nice, thanks for open-sourcing it. I do not write a lot of scripts but when I do it's nice to have simpler and somewhat familiar (although more restrictive) alternative to bash.

If your vision of future development of this project does not include having Semigroup instance for InfoMod, feel free to close my MRs.
